### PR TITLE
feat: 결제 승인 시 주문 상태 업데이트 및 포인트 차감 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,10 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.3'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.3'
 
-
+    // test lombok
+    testImplementation 'org.projectlombok:lombok:1.18.28'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.28'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/mollyapi/order/entity/Order.java
+++ b/src/main/java/org/example/mollyapi/order/entity/Order.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder(toBuilder = true) // ✅ 빌더 설정을 여기에 유지
+@Builder(toBuilder = true)
 @Table(name = "orders")
 public class Order {
 
@@ -22,7 +22,7 @@ public class Order {
     private Long id; // pk
 
     @Column(name = "toss_order_id",unique = true, length = 30)
-    private String tossOrderId; // 결제용 주문 id
+    private String tossOrderId; // 결제용 주문 ID
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
@@ -32,10 +32,19 @@ public class Order {
     private List<OrderDetail> orderDetails;
 
     @Column(nullable = false)
-    private Long totalAmount; // 포인트 적용 전
+    private Long totalAmount; // 포인트 적용 전 금액
 
     @Column(nullable = true)
-    private Long paymentAmount; // 결제 예정 금액
+    private Long paymentAmount; // 결제된 금액
+
+    @Column(nullable = true)
+    private String paymentId; // 결제 ID
+
+    @Column(nullable = true)
+    private String paymentType; // 결제 수단
+
+    @Column(nullable = true)
+    private Integer pointUsage; // 사용한 포인트
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -57,6 +66,10 @@ public class Order {
         this.expirationTime = this.orderedAt.plusMinutes(10);
     }
 
+    public void setStatus(OrderStatus status) {
+        this.status = status;
+    }
+
     public void updateOrderedAt(LocalDateTime paymentTime) { // 결제 후 주문 일시 업데이트
         this.orderedAt = paymentTime;
     }
@@ -74,11 +87,10 @@ public class Order {
         this.totalAmount = totalAmount;
     }
 
-//    public void setOrderNumber(String orderNumber) {
-//        if (this.orderNumber == null) {
-//            this.orderNumber = orderNumber;
-//        } else {
-//            throw new IllegalStateException("주문번호는 한 번만 설정할 수 있습니다.");
-//        }
-//    }
+    public void updatePaymentInfo(String paymentId, String paymentType, Long paymentAmount, Integer pointUsage) {
+        this.paymentId = paymentId;
+        this.paymentType = paymentType;
+        this.paymentAmount = paymentAmount;
+        this.pointUsage = pointUsage;
+    }
 }

--- a/src/main/java/org/example/mollyapi/order/repository/OrderRepository.java
+++ b/src/main/java/org/example/mollyapi/order/repository/OrderRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
     Optional<Order> findById(Long orderId);
+    Optional<Order> findByTossOrderId(String tossOrderId);
 }

--- a/src/main/java/org/example/mollyapi/user/entity/User.java
+++ b/src/main/java/org/example/mollyapi/user/entity/User.java
@@ -82,4 +82,11 @@ public class User extends Base {
         this.flag = true;
     }
 
+    public void updatePoint(int amount) {
+        if (this.point == null) {
+            this.point = 0;
+        }
+        this.point += amount;
+    }
+
 }

--- a/src/test/java/org/example/mollyapi/OrderServiceTest.java
+++ b/src/test/java/org/example/mollyapi/OrderServiceTest.java
@@ -1,36 +1,75 @@
 package org.example.mollyapi;
 
-import jakarta.transaction.Transactional;
-import org.example.mollyapi.order.dto.OrderRequestDto;
+import lombok.extern.slf4j.Slf4j;
+import org.example.mollyapi.order.entity.Order;
+import org.example.mollyapi.order.repository.OrderRepository;
 import org.example.mollyapi.order.service.OrderService;
-import org.example.mollyapi.product.dto.UploadFile;
-import org.example.mollyapi.product.dto.request.ProductItemReqDto;
-import org.example.mollyapi.product.dto.request.ProductRegisterReqDto;
-import org.example.mollyapi.product.entity.Category;
-import org.example.mollyapi.product.entity.Product;
-import org.example.mollyapi.product.entity.ProductItem;
-import org.example.mollyapi.product.service.ProductServiceImpl;
-import org.example.mollyapi.user.auth.dto.SignInReqDto;
-import org.example.mollyapi.user.auth.service.SignInService;
-import org.example.mollyapi.user.dto.SignUpReqDto;
+import org.example.mollyapi.order.type.OrderStatus;
 import org.example.mollyapi.user.entity.User;
-import org.example.mollyapi.user.service.SignUpService;
-import org.example.mollyapi.user.type.Sex;
-import org.junit.jupiter.api.Test;
+import org.example.mollyapi.user.repository.UserRepository;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
-public class OrderServiceTest {
+@Slf4j
+class OrderServiceTest {
 
     @Autowired
-    OrderService service;
+    private OrderService orderService;
+
     @Autowired
-    private ProductServiceImpl productServiceImpl;
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private Order testOrder;
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        // DB에서 User 조회 (id=1)
+        testUser = userRepository.findById(1L)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        // DB에서 주문 조회 (tossOrderId 사용)
+        testOrder = orderRepository.findByTossOrderId("ORD-20250213132457-6375")
+                .orElseThrow(() -> new IllegalArgumentException("주문을 찾을 수 없습니다."));
+
+        log.info("테스트 유저: {} , 포인트: {} " ,testUser.getNickname(), testUser.getPoint());
+        log.info("테스트 주문: {}, 상태: {} " ,testOrder.getTossOrderId(), testOrder.getStatus());
+    }
 
     @Test
-    void OrderTest(){
+    void testSuccessOrder() {
+        // Given: 결제 성공 정보
+        String fakePaymentId = "PAY-12345";
+        String fakePaymentType = "CARD";
+        Long fakePaymentAmount = 258000L;
+        Integer fakePointUsage = 5000;
 
+        // When: successOrder() 실행
+        orderService.successOrder("ORD-20250213132457-6375", fakePaymentId, fakePaymentType, fakePaymentAmount, fakePointUsage);
+
+        // Then: 주문 상태 변경 확인
+        assertEquals(OrderStatus.SUCCEEDED, testOrder.getStatus());
+        assertEquals(fakePaymentId, testOrder.getPaymentId());
+        assertEquals(fakePaymentType, testOrder.getPaymentType());
+        assertEquals(fakePaymentAmount, testOrder.getPaymentAmount());
+        assertEquals(fakePointUsage, testOrder.getPointUsage());
+
+        // 포인트 차감 확인
+        assertEquals(100000 - fakePointUsage, testUser.getPoint());  // 원래 포인트에서 차감됐는지 확인
+
+        // 테스트 결과 출력
+        log.info("successOrder 테스트 결과:");
+        log.info("Order status: {}", testOrder.getStatus());
+        log.info("Order payment 정보: paymentId={}, paymentType={}, paymentAmount={}", testOrder.getPaymentId(), testOrder.getPaymentType(), testOrder.getPaymentAmount());
+        log.info("Order point_usage: {}", testOrder.getPointUsage());
+        log.info("User point: {}", testUser.getPoint());
     }
 }


### PR DESCRIPTION
## 개요
feat: 결제 승인 시 주문 상태 업데이트 및 포인트 차감 로직 구현
- `findByTossOrderId`: toss_order_id로 주문 조회 메서드 추가
- `successOrder` 메서드 구현:
  - Order.status='SUCCEEDED'로 변경
  - Order.point_usage 저장
  - 결제 승인 시 User.point 차감
  - Order에 payment_id, payment_type, payment_amount 업데이트

chore: 테스트 환경에서 Lombok 및 JUnit 설정 추가
- testImplementation 및 testAnnotationProcessor에 Lombok 추가 (v1.18.28)
- testRuntimeOnly에 JUnit 플랫폼 런처 추가
<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
<img width="1325" alt="successOrderTest" src="https://github.com/user-attachments/assets/8476a4e8-d4a0-4b0e-82d6-b24ba458a590" />

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
