### PR TITLE
fix: purchaseCount null 방어 및 초기값 설정

### DIFF
--- a/src/main/java/org/example/mollyapi/product/entity/Product.java
+++ b/src/main/java/org/example/mollyapi/product/entity/Product.java
@@ -1,20 +1,18 @@
 package org.example.mollyapi.product.entity;
 
 import jakarta.persistence.*;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.example.mollyapi.common.entity.Base;
 import org.example.mollyapi.product.dto.UploadFile;
 import org.example.mollyapi.user.entity.User;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Getter
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Product extends Base {
 
     @Id
@@ -29,7 +27,11 @@ public class Product extends Base {
     String productName;
     Long price;
     String description;
+
+    @Column(nullable = false)
     Long viewCount = 0L;
+
+    @Column(nullable = false)
     Long purchaseCount = 0L;
 
     @OneToMany(mappedBy = "product", cascade = CascadeType.ALL)
@@ -57,6 +59,8 @@ public class Product extends Base {
         this.price = price;
         this.description = description;
         this.user = user;
+        this.viewCount = 0L;
+        this.purchaseCount = 0L;
     }
 
     public void increaseViewCount() {
@@ -64,11 +68,11 @@ public class Product extends Base {
     }
 
     public void increasePurchaseCount() {
-        this.purchaseCount++;
+        this.purchaseCount = Optional.ofNullable(this.purchaseCount).orElse(0L) + 1;
     }
 
     public void decreasePurchaseCount() {
-        this.purchaseCount--;
+        this.purchaseCount = Math.max(0, Optional.ofNullable(this.purchaseCount).orElse(0L) - 1);
     }
 
     public void addImage(ProductImage productImage) {
@@ -123,7 +127,10 @@ public class Product extends Base {
         this.productName = productName;
         this.price = price;
         this.description = description;
-
         return this;
+    }
+
+    public void setPurchaseCount(long purchaseCount) {
+        this.purchaseCount = purchaseCount;
     }
 }


### PR DESCRIPTION
## 개요
- purchaseCount가 null이 될 경우 발생하는 NullPointerException 수정
- 엔티티 필드에 @Column(nullable = false) 추가하여 기본값 0L 설정
- increasePurchaseCount() 및 decreasePurchaseCount()에서 null 방어 처리
- decreasePurchaseCount()에서 0 이하로 내려가지 않도록 Math.max 적용
- 
<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
<img width="863" alt="image" src="https://github.com/user-attachments/assets/3151418d-fa48-4827-973e-58e1a4ae8b79" />


- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
