### PR TITLE
feat: 배송 상태 변경 API 추가

### DIFF
--- a/src/main/java/org/example/mollyapi/delivery/controller/DeliveryController.java
+++ b/src/main/java/org/example/mollyapi/delivery/controller/DeliveryController.java
@@ -1,0 +1,38 @@
+package org.example.mollyapi.delivery.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.mollyapi.delivery.service.DeliveryService;
+import org.example.mollyapi.delivery.type.DeliveryStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/delivery")
+@Slf4j
+public class DeliveryController {
+
+    private final DeliveryService deliveryService;
+
+    // 출고 처리 API (READY → SHIPPING)
+    @PostMapping("/{orderId}/ship")
+    public ResponseEntity<String> shipOrder(@PathVariable Long orderId) {
+        deliveryService.updateDeliveryStatus(orderId, DeliveryStatus.SHIPPING);
+        return ResponseEntity.ok("출고 처리 완료 (READY → SHIPPING)");
+    }
+
+    // 배송 완료 API (SHIPPING → ARRIVED)
+    @PostMapping("/{orderId}/arrive")
+    public ResponseEntity<String> arriveOrder(@PathVariable Long orderId) {
+        deliveryService.updateDeliveryStatus(orderId, DeliveryStatus.ARRIVED);
+        return ResponseEntity.ok("배송 완료 (SHIPPING → ARRIVED)");
+    }
+
+    // 반품 도착 API (RETURN_REQUESTED → RETURN_ARRIVED)
+    @PostMapping("/{orderId}/return-arrive")
+    public ResponseEntity<String> returnArrive(@PathVariable Long orderId) {
+        deliveryService.updateDeliveryStatus(orderId, DeliveryStatus.RETURN_ARRIVED);
+        return ResponseEntity.ok("🔄 반품 도착 처리 완료 (RETURN_REQUESTED → RETURN_ARRIVED)");
+    }
+}

--- a/src/main/java/org/example/mollyapi/delivery/service/DeliveryService.java
+++ b/src/main/java/org/example/mollyapi/delivery/service/DeliveryService.java
@@ -22,24 +22,34 @@ public class DeliveryService {
     private final UserRepository userRepository;
 
     @Transactional
-    public void updateDeliveryStatus(Long deliveryId, DeliveryStatus status) {
-        Delivery delivery = deliveryRepository.findById(deliveryId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 배송 정보를 찾을 수 없습니다. deliveryId=" + deliveryId));
+    public void updateDeliveryStatus(Long orderId, DeliveryStatus status) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 주문 정보를 찾을 수 없습니다. orderId=" + orderId));
 
-        log.info("배송 상태 변경: Delivery Id = {}, status = {}", delivery.getId(), status);
+        Delivery delivery = order.getDelivery();
+        if (delivery == null) {
+            throw new IllegalStateException("해당 주문에 연결된 배송 정보가 없습니다. orderId=" + orderId);
+        }
+
+        log.info("배송 상태 변경: orderId={}, deliveryId={}, {} → {}", orderId, delivery.getId(), delivery.getStatus(), status);
         delivery.setStatus(status);
         deliveryRepository.save(delivery);
 
         // 배송이 ARRIVED 상태로 변경되면 포인트 적립
         if (status == DeliveryStatus.ARRIVED) {
-            applyPointReward(delivery);
+            applyPointReward(order);
         }
     }
 
     @Transactional
-    public void applyPointReward(Delivery delivery) {
-        Order order = delivery.getOrder();
+    public void applyPointReward(Order order) {
         User user = order.getUser();
+
+        // 포인트 적립된 경우 중복 적립 방지
+        if (order.getPointSave() != null && order.getPointSave() > 0) {
+            log.warn("이미 적립된 포인트가 존재하여 적립을 중단합니다. orderId={}, 기존 적립 포인트={}", order.getId(), order.getPointSave());
+            return;
+        }
 
         // 주문 금액의 10% 포인트 적립 (소수점 버림)
         int rewardPoint = (int) (order.getPaymentAmount() * 0.1);

--- a/src/main/java/org/example/mollyapi/order/service/OrderService.java
+++ b/src/main/java/org/example/mollyapi/order/service/OrderService.java
@@ -272,8 +272,8 @@ public class OrderService {
         delivery.setStatus(DeliveryStatus.RETURN_REQUESTED);
         deliveryRepository.save(delivery);
 
-        delivery.setStatus(DeliveryStatus.RETURN_ARRIVED);
-        deliveryRepository.save(delivery);
+//        delivery.setStatus(DeliveryStatus.RETURN_ARRIVED); // 반품 완료 처리는 API에서 수행하도록 분리
+//        deliveryRepository.save(delivery);
 
         // 포인트 환불
         refundUserPoints(order);


### PR DESCRIPTION
## 개요
- 출고 처리 API (READY → SHIPPING) 추가: `POST /delivery/{orderId}/ship`
- 배송 완료 API (SHIPPING → ARRIVED) 추가: `POST /delivery/{orderId}/arrive`
- 반품 도착 API (RETURN_REQUESTED → RETURN_ARRIVED) 추가: `POST /delivery/{orderId}/return-arrive`
- 배송 상태 변경 시 유효성 검사 추가 (잘못된 상태 변경 방지)
- 배송 ID(기존 방식) 대신 주문 ID를 통해 배송 정보 조회 후 상태 업데이트하도록 구현
- 기존 OrderService의 handlePostShippingCancellation에서 RETURN_ARRIVED 처리 로직을 API로 분리

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
<img width="1036" alt="readytoshipping" src="https://github.com/user-attachments/assets/49b26280-a790-4e8a-bb91-538542083dcd" />
<img width="1037" alt="returnarrived" src="https://github.com/user-attachments/assets/d078d0c0-19ce-4415-85cc-b6390d3d489c" />
<img width="1041" alt="shippingtoarrived" src="https://github.com/user-attachments/assets/17133b72-a9ee-4a1a-a578-0abaccb58cf6" />

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
