### PR TITLE
108 feat 비회원용 리뷰 내역 조회 API 구현

### DIFF
--- a/src/main/java/org/example/mollyapi/review/controller/ReviewController.java
+++ b/src/main/java/org/example/mollyapi/review/controller/ReviewController.java
@@ -69,7 +69,26 @@ public class ReviewController {
             HttpServletRequest request
     ) {
         Long userId = (Long) request.getAttribute("userId");
-        if(userId == null) userId = 0L;
+        PageRequest pageRequest = PageRequest.of(page, size);
+        return reviewService.getReviewList(pageRequest, productId, userId);
+    }
+
+    @GetMapping("/{productId}/new")
+    @Operation(summary = "비회원용 상품별 리뷰 내역 조회 API", description = "상품의 리뷰를 조회할 수 있습니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "리뷰 조회 성공",
+                    content = @Content(schema = @Schema(implementation = GetReviewResDto.class))),
+            @ApiResponse(responseCode = "204", description = "등록된 리뷰가 없는 상품",
+                    content = @Content(schema = @Schema(implementation = CommonResDto.class))),
+            @ApiResponse(responseCode = "400", description = "1. 존재 하지 않는 상품 \t\n 2. 리뷰 조회 실패",
+                    content = @Content(schema = @Schema(implementation = CustomErrorResponse.class)))
+    })
+    public ResponseEntity<?> getReviewListByNonUser(
+            @PathVariable Long productId,
+            @RequestParam int page,
+            @RequestParam int size
+    ) {
+        Long userId = 0L; //비회원으로 체크
         PageRequest pageRequest = PageRequest.of(page, size);
         return reviewService.getReviewList(pageRequest, productId, userId);
     }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
### 비회원용 리뷰 내역 조회 기능
* 기존의 API의 경우 @Auth로 인해 로그인한 사용자만 조회를 할 수 있어, @Auth가 없는 API를 추가 개발

Resolves: #108

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
### 비회원 리뷰 조회 성공시
<img width="810" alt="스크린샷 2025-02-20 오후 4 44 17" src="https://github.com/user-attachments/assets/99cfabde-b0e3-4097-8a28-0abaacbdc492" />

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
