### PR TITLE
feat: 주문 생성 로직 개선 - 장바구니 주문과 바로 주문 분리

### DIFF
--- a/src/main/java/org/example/mollyapi/order/dto/OrderRequestDto.java
+++ b/src/main/java/org/example/mollyapi/order/dto/OrderRequestDto.java
@@ -7,13 +7,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class OrderRequestDto {
     private Long cartId;
-    private Long productId;
     private Long itemId;
     private Long quantity;
 
-    public OrderRequestDto(Long cartId, Long productId, Long itemId, Long quantity) {
+    public OrderRequestDto(Long cartId, Long itemId, Long quantity) {
         this.cartId = cartId;
-        this.productId = productId;
         this.itemId = itemId;
         this.quantity = quantity;
     }


### PR DESCRIPTION
## 개요
- 장바구니에서 주문 시(요청에 cartId 포함) → 해당 cartId로 저장된 itemId, quantity 조회 후 주문 생성
- 상품 상세 페이지에서 바로 주문 시(cartId 없음) → itemId와 quantity를 직접 받아 주문 생성
- 위의 두가지 주문 로직은 통합하여 관리: 두 가지 주문 방식 처리 가능하도록 구현함
- 나머지 로직(주문 시 재고 검증 및 차감)은 유지
- OrderRequestDto 수정: productId삭제, cartId, itemId, quantity 필요한 데이터만 활용하도록 변경

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

장바구니에서 주문 생성
<img width="967" alt="carttoorder" src="https://github.com/user-attachments/assets/9771b26e-9ed2-49a3-9146-56e2b9306238" />

상품페이지에서 바로 주문으로 주문 생성
<img width="965" alt="directorder" src="https://github.com/user-attachments/assets/7c93df22-35c6-425d-8291-85459ae4e7cd" />

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
