### PR TITLE
feat: ExpiredOrders 삭제 자동 스케줄러 구현

### DIFF
--- a/src/main/java/org/example/mollyapi/delivery/entity/Delivery.java
+++ b/src/main/java/org/example/mollyapi/delivery/entity/Delivery.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.example.mollyapi.delivery.type.DeliveryStatus;
 import org.example.mollyapi.order.entity.Order;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Getter
 @Setter
@@ -38,8 +40,9 @@ public class Delivery {
     @Column(nullable = false)
     private String addrDetail;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "order_id", nullable = false)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @JoinColumn(name = "order_id", nullable = false, foreignKey = @ForeignKey(name = "FK_DELIVERY_ORDER"))
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Order order; // 주문 정보와 1:1 매핑
 
     public static Delivery from(Order order, String receiverName, String receiverPhone, String roadAddress, String numberAddress, String addrDetail) {

--- a/src/main/java/org/example/mollyapi/order/controller/OrderController.java
+++ b/src/main/java/org/example/mollyapi/order/controller/OrderController.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.example.mollyapi.common.exception.CustomErrorResponse;
 import org.example.mollyapi.order.dto.OrderCreateRequestDto;
 import org.example.mollyapi.order.dto.OrderHistoryResponseDto;
+import org.example.mollyapi.order.dto.OrderRequestDto;
 import org.example.mollyapi.order.dto.OrderResponseDto;
 import org.example.mollyapi.order.service.OrderService;
 import org.example.mollyapi.user.auth.annotation.Auth;
@@ -32,8 +33,12 @@ public class OrderController {
     @PostMapping(produces = "application/json")
     public ResponseEntity<OrderResponseDto> createOrder(@Valid @RequestBody List<Long> cartIds, HttpServletRequest httpRequest) {
         Long userId = (Long) httpRequest.getAttribute("userId");
-        OrderResponseDto response = orderService.createOrder(userId, cartIds);
 
+        List<OrderRequestDto> orderRequests = cartIds.stream()
+                .map(cartId -> new OrderRequestDto(cartId, null, null)) // itemId와 quantity는 null
+                .toList();
+
+        OrderResponseDto response = orderService.createOrder(userId, orderRequests);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/org/example/mollyapi/order/entity/Order.java
+++ b/src/main/java/org/example/mollyapi/order/entity/Order.java
@@ -5,7 +5,11 @@ import lombok.*;
 import org.example.mollyapi.delivery.entity.Delivery;
 import org.example.mollyapi.order.type.CancelStatus;
 import org.example.mollyapi.order.type.OrderStatus;
+import org.example.mollyapi.payment.entity.Payment;
 import org.example.mollyapi.user.entity.User;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -32,9 +36,15 @@ public class Order {
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OrderDetail> orderDetails;
 
-    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    @JoinColumn(name = "delivery_id") // FK 설정
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "delivery_id", foreignKey = @ForeignKey(name = "FK_DELIVERY_ORDER"))
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Delivery delivery;
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private List<Payment> payments;
+
 
     @Column(nullable = false)
     private Long totalAmount; // 포인트 적용 전 금액

--- a/src/main/java/org/example/mollyapi/order/repository/OrderDetailRepository.java
+++ b/src/main/java/org/example/mollyapi/order/repository/OrderDetailRepository.java
@@ -2,9 +2,26 @@ package org.example.mollyapi.order.repository;
 
 import org.example.mollyapi.order.entity.OrderDetail;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 public interface OrderDetailRepository extends JpaRepository<OrderDetail, Long> {
     List<OrderDetail> findByOrderId(Long orderId);
+
+    @Transactional
+    @Modifying
+    @Query("DELETE FROM OrderDetail od WHERE od.order.id = :orderId")
+    void deleteByOrderId(@Param("orderId") Long orderId);
+
+    @Query("SELECT od.id FROM OrderDetail od WHERE od.order.id IN :orderIds")
+    List<Long> findOrderDetailIdsByOrderIds(@Param("orderIds") List<Long> orderIds);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM OrderDetail od WHERE od.order.id IN :orderIds")
+    int deleteAllByOrderIds(@Param("orderIds") List<Long> orderIds);
 }

--- a/src/main/java/org/example/mollyapi/order/repository/OrderRepository.java
+++ b/src/main/java/org/example/mollyapi/order/repository/OrderRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -19,5 +20,8 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 
     @Query("SELECT o FROM Order o WHERE o.user = :user AND o.status IN (:statuses)")
     List<Order> findOrdersByUserAndStatusIn(@Param("user") User user, @Param("statuses") List<OrderStatus> statuses);
+
+    @Query("SELECT o FROM Order o WHERE o.expirationTime < :now AND o.status = 'PENDING'")
+    List<Order> findExpiredPendingOrders(@Param("now") LocalDateTime now);
 
 }

--- a/src/main/java/org/example/mollyapi/order/service/OrderCleanupScheduler.java
+++ b/src/main/java/org/example/mollyapi/order/service/OrderCleanupScheduler.java
@@ -1,0 +1,23 @@
+package org.example.mollyapi.order.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderCleanupScheduler {
+
+    private final OrderSchedulerService orderSchedulerService;
+
+    // 매일 오후 2시 28분에 ExpiredOrders 삭제
+    @Scheduled(cron = "0 28 14 * * *")
+    public void cleanUpExpiredOrders() {
+        log.info("[Scheduler] 시작: 만료된 주문 삭제 시작");
+        int deletedCount = orderSchedulerService.deleteExpiredOrders();
+        log.info("[Scheduler] 완료: {}개의 만료된 주문이 삭제됨", deletedCount);
+    }
+}

--- a/src/main/java/org/example/mollyapi/order/service/OrderSchedulerService.java
+++ b/src/main/java/org/example/mollyapi/order/service/OrderSchedulerService.java
@@ -1,0 +1,73 @@
+package org.example.mollyapi.order.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.mollyapi.order.entity.Order;
+import org.example.mollyapi.order.repository.OrderDetailRepository;
+import org.example.mollyapi.order.repository.OrderRepository;
+import org.example.mollyapi.review.repository.ReviewImageRepository;
+import org.example.mollyapi.review.repository.ReviewLikeRepository;
+import org.example.mollyapi.review.repository.ReviewRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OrderSchedulerService {
+    private final OrderRepository orderRepository;
+    private final OrderDetailRepository orderDetailRepository;
+    private final ReviewRepository reviewRepository;
+    private final ReviewImageRepository reviewImageRepository;
+    private final ReviewLikeRepository reviewLikeRepository;
+
+    @Transactional
+    public int deleteExpiredOrders() {
+        List<Order> expiredOrders = orderRepository.findExpiredPendingOrders(LocalDateTime.now());
+
+        if (expiredOrders.isEmpty()) {
+            log.info("삭제할 만료된 주문 없음");
+            return 0;
+        }
+
+        List<Long> orderIds = expiredOrders.stream().map(Order::getId).toList();
+        log.info("삭제할 주문 ID 목록: {}", orderIds);
+        List<Long> orderDetailIds = orderDetailRepository.findOrderDetailIdsByOrderIds(orderIds);
+
+        if (!orderDetailIds.isEmpty()) {
+            // 리뷰 ID 가져오기
+            List<Long> reviewIds = reviewRepository.findReviewIdsByOrderDetailIds(orderDetailIds);
+
+            // ReviewImage 삭제
+            if (!reviewIds.isEmpty()) {
+                reviewImageRepository.deleteAllByReviewIdIn(reviewIds);
+                log.info("삭제된 리뷰 이미지 개수: {}", reviewIds.size());
+            }
+
+            // ReviewLike 삭제
+            if (!reviewIds.isEmpty()) {
+                reviewLikeRepository.deleteAllByReviewIdIn(reviewIds);
+                log.info("삭제된 리뷰 좋아요 개수: {}", reviewIds.size());
+            }
+
+            // Review 삭제
+            int deletedReviews = reviewRepository.deleteByOrderDetailIds(orderDetailIds);
+            log.info("삭제된 리뷰 개수: {}", deletedReviews);
+        } else {
+            log.info("삭제할 리뷰 없음");
+        }
+
+        // OrderDetail 삭제
+        int deletedOrderDetails = orderDetailRepository.deleteAllByOrderIds(orderIds);
+        log.info("삭제된 주문 상세 개수: {}", deletedOrderDetails);
+
+        // Order 삭제
+        orderRepository.deleteAll(expiredOrders);
+        log.info("삭제된 주문 개수: {}, 삭제된 주문 ID", orderIds.size(), orderIds);
+
+        return orderIds.size();
+    }
+}

--- a/src/main/java/org/example/mollyapi/payment/entity/Payment.java
+++ b/src/main/java/org/example/mollyapi/payment/entity/Payment.java
@@ -11,6 +11,8 @@ import org.example.mollyapi.common.exception.error.impl.PaymentError;
 import org.example.mollyapi.order.entity.Order;
 import org.example.mollyapi.payment.type.PaymentStatus;
 import org.example.mollyapi.user.entity.User;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.time.LocalDateTime;
 
@@ -49,8 +51,9 @@ public class Payment extends Base {
     @Enumerated(EnumType.STRING)
     private PaymentStatus paymentStatus;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "order_id")
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @JoinColumn(name = "order_id", nullable = false, foreignKey = @ForeignKey(name = "FK_PAYMENT_ORDER"))
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Order order;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/org/example/mollyapi/review/entity/Review.java
+++ b/src/main/java/org/example/mollyapi/review/entity/Review.java
@@ -6,6 +6,8 @@ import org.example.mollyapi.common.entity.Base;
 import org.example.mollyapi.order.entity.OrderDetail;
 import org.example.mollyapi.product.entity.Product;
 import org.example.mollyapi.user.entity.User;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,8 +34,9 @@ public class Review extends Base {
     @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "FK_REVIEW_USER"))
     private User user;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JoinColumn(name = "order_detail_id", foreignKey = @ForeignKey(name = "FK_REVIEW_ORDERDETAIL"))
+    @OnDelete(action= OnDeleteAction.CASCADE)
     private OrderDetail orderDetail;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/org/example/mollyapi/review/entity/ReviewImage.java
+++ b/src/main/java/org/example/mollyapi/review/entity/ReviewImage.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.example.mollyapi.common.entity.Base;
 import org.example.mollyapi.product.dto.UploadFile;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Builder
@@ -29,8 +31,9 @@ public class ReviewImage extends Base {
     @Column(name = "is_video", nullable = false, columnDefinition = "TINYINT(1) DEFAULT 0")
     private Boolean isVideo; //비디오 여부. 0: False, 1: True
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JoinColumn(name = "review_id", nullable = false, foreignKey = @ForeignKey(name = "FK_LIKE_REVIEW"))
+    @OnDelete(action= OnDeleteAction.CASCADE)
     private Review review;
 
     @Builder

--- a/src/main/java/org/example/mollyapi/review/entity/ReviewLike.java
+++ b/src/main/java/org/example/mollyapi/review/entity/ReviewLike.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.example.mollyapi.common.entity.Base;
 import org.example.mollyapi.user.entity.User;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Builder
@@ -24,8 +26,9 @@ public class ReviewLike extends Base {
     @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "FK_LIKE_USER"))
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JoinColumn(name = "review_id", nullable = false, foreignKey = @ForeignKey(name = "FK_LIKE_REVIEW"))
+    @OnDelete(action= OnDeleteAction.CASCADE)
     private Review review;
 
     public boolean updateIsLike(boolean isLike) {

--- a/src/main/java/org/example/mollyapi/review/repository/ReviewImageRepository.java
+++ b/src/main/java/org/example/mollyapi/review/repository/ReviewImageRepository.java
@@ -2,7 +2,12 @@ package org.example.mollyapi.review.repository;
 
 import org.example.mollyapi.review.entity.ReviewImage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> {
     void deleteAllByReviewId(Long reviewId);
+    @Transactional
+    void deleteAllByReviewIdIn(List<Long> reviewIds);
 }

--- a/src/main/java/org/example/mollyapi/review/repository/ReviewLikeRepository.java
+++ b/src/main/java/org/example/mollyapi/review/repository/ReviewLikeRepository.java
@@ -2,8 +2,13 @@ package org.example.mollyapi.review.repository;
 
 import org.example.mollyapi.review.entity.ReviewLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
     ReviewLike findByReviewIdAndUserUserId(Long reviewId, Long userId);
     void deleteAllByReviewId(Long reviewId);
+    @Transactional
+    void deleteAllByReviewIdIn(List<Long> reviewIds);
 }

--- a/src/main/java/org/example/mollyapi/review/repository/ReviewRepository.java
+++ b/src/main/java/org/example/mollyapi/review/repository/ReviewRepository.java
@@ -2,11 +2,24 @@ package org.example.mollyapi.review.repository;
 
 import org.example.mollyapi.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewCustomRepository {
     Review findByIsDeletedAndOrderDetailIdAndUserUserId(Boolean isDeleted, Long orderDetail, Long userId);
     Optional<Review> findByIdAndIsDeleted(Long reviewId, Boolean isDeleted);
     Optional<Review> findByIdAndUserUserId(Long reviewId, Long userId);
+
+    @Query("SELECT r.id FROM Review r WHERE r.orderDetail.id IN :orderDetailIds")
+    List<Long> findReviewIdsByOrderDetailIds(@Param("orderDetailIds") List<Long> orderDetailIds);
+
+    @Transactional
+    @Modifying
+    @Query("DELETE FROM Review r WHERE r.orderDetail.id IN :orderDetailIds")
+    int deleteByOrderDetailIds(@Param("orderDetailIds") List<Long> orderDetailIds);
 }


### PR DESCRIPTION
## 개요
- 만료된 주문 자동 삭제 스케줄러 `OrderCleanupScheduler`추가
   - 일정 주기로 만료된 주문을 삭제(@Scheduled)
   - `OrderSchedulerService`에서 만료된 주문을 조회하고 삭제하는 로직 추가
- Order 삭제 시 관련 엔티티(Review, Delivery, Payment)도 함께 삭제되도록 설정
   - `Order` 엔티티에서 `Review`, `Delivery`, `Payment`에 `@OnDelete(action = OnDeleteAction.CASCADE)` 추가
   - `Delivery`, `Payment` 엔티티에도 `@OnDelete(action = OnDeleteAction.CASCADE)` 설정하여 참조 무결성 보장
   - Hibernate 자동 생성 시 `ON DELETE CASCADE`가 적용되도록 설정
- MySQL FK 제약 조건을 `ON DELETE CASCADE`로 변경

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
expired orders 삭제 전
<img width="1357" alt="deleteExpiredOrdersb4" src="https://github.com/user-attachments/assets/fa45672d-d6e0-4e72-9fd7-0c31e354d463" />

expired orders 삭제 후
<img width="1352" alt="deleteExpiredOrdersar" src="https://github.com/user-attachments/assets/7e8ed89e-c42e-41ce-88e6-51a9dab813df" />

expired orders 삭제 스케줄러
<img width="1312" alt="deleteExpiredOrders" src="https://github.com/user-attachments/assets/fe37418c-c11d-41ab-96c1-9bb046719a91" />



- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
