### PR TITLE
fix: 주문 생성 API 개선 및 OrderRequestDto 수정

### DIFF
--- a/src/main/java/org/example/mollyapi/order/controller/OrderController.java
+++ b/src/main/java/org/example/mollyapi/order/controller/OrderController.java
@@ -30,14 +30,10 @@ public class OrderController {
     private final OrderService orderService;
 
     @Auth
-    @PostMapping(produces = "application/json")
-    public ResponseEntity<OrderResponseDto> createOrder(@Valid @RequestBody List<Long> cartIds, HttpServletRequest httpRequest) {
+    @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<OrderResponseDto> createOrder(
+            @Valid @RequestBody List<OrderRequestDto> orderRequests, HttpServletRequest httpRequest) {
         Long userId = (Long) httpRequest.getAttribute("userId");
-
-        List<OrderRequestDto> orderRequests = cartIds.stream()
-                .map(cartId -> new OrderRequestDto(cartId, null, null)) // itemId와 quantity는 null
-                .toList();
-
         OrderResponseDto response = orderService.createOrder(userId, orderRequests);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/org/example/mollyapi/order/dto/OrderRequestDto.java
+++ b/src/main/java/org/example/mollyapi/order/dto/OrderRequestDto.java
@@ -1,5 +1,7 @@
 package org.example.mollyapi.order.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,9 +12,20 @@ public class OrderRequestDto {
     private Long itemId;
     private Long quantity;
 
-    public OrderRequestDto(Long cartId, Long itemId, Long quantity) {
+    @JsonCreator
+    public OrderRequestDto(
+            @JsonProperty("cartId") Long cartId,
+            @JsonProperty("itemId") Long itemId,
+            @JsonProperty("quantity") Long quantity) {
         this.cartId = cartId;
         this.itemId = itemId;
         this.quantity = quantity;
+
+        if (cartId != null && (itemId != null || quantity != null)) {
+            throw new IllegalArgumentException("장바구니 주문이므로 itemId와 quantity는 포함될 수 없습니다.");
+        }
+        if (cartId == null && (itemId == null || quantity == null)) {
+            throw new IllegalArgumentException("바로 주문이므로 itemId와 quantity는 필수입니다.");
+        }
     }
 }

--- a/src/main/java/org/example/mollyapi/order/service/OrderService.java
+++ b/src/main/java/org/example/mollyapi/order/service/OrderService.java
@@ -117,7 +117,7 @@ public class OrderService {
             Long itemId;
             Long quantity;
 
-            // 장바구니 -> 주문일 경우. cartId를 받아서 DB에서 itemId, quantity 가져옴
+            // 장바구니에서 주문할 경우
             if (req.getCartId() != null) {
                 Cart cart = cartRepository.findById(req.getCartId())
                         .orElseThrow(() -> new IllegalArgumentException("장바구니 항목을 찾을 수 없습니다. cartId=" + req.getCartId()));
@@ -125,7 +125,7 @@ public class OrderService {
                 itemId = cart.getProductItem().getId();
                 quantity = cart.getQuantity();
             } else {
-                // 상품 페이지에서의 바로 주문일 경우. cartId없이 itemId와 quantity 직접 사용
+                // 바로 주문할 경우
                 itemId = req.getItemId();
                 quantity = req.getQuantity();
             }


### PR DESCRIPTION
## 개요
- OrderRequestDto 수정:
  - cartId가 있을 경우 itemId와 quantity는 받을 수 없도록 유효성 검사 추가
  - cartId가 없을 경우 itemId와 quantity를 필수로 받도록 설정
  - @JsonCreator와 @JsonProperty 추가하여 Swagger에서 DTO 올바르게 표시되도록 개선
- 주문 생성 API 수정:
  - @RequestBody에서 List<Long> → List<OrderRequestDto>로 변경
  - cartId가 존재하면 장바구니 기반 주문 처리
  - cartId가 없으면 바로 구매 주문 처리
  - 상품 재고 확인 및 차감 로직 개선

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

장바구니 주문
<img width="969" alt="orderfix022501" src="https://github.com/user-attachments/assets/2e9e620a-2cdd-4145-b11a-3995706a84d7" />

바로 주문
<img width="970" alt="orderfix022502" src="https://github.com/user-attachments/assets/f0ec7174-f319-4ebb-87dc-6f3a34facc4d" />

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
