### PR TITLE
fix: 장바구니 주문과 바로 주문을 분리하여 DTO 및 Controller 수정

### DIFF
--- a/src/main/java/org/example/mollyapi/order/dto/CartOrderRequestDto.java
+++ b/src/main/java/org/example/mollyapi/order/dto/CartOrderRequestDto.java
@@ -1,0 +1,20 @@
+package org.example.mollyapi.order.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CartOrderRequestDto {
+    private Long cartId;
+
+    @JsonCreator
+    public CartOrderRequestDto(@JsonProperty("cartId") Long cartId) {
+        if (cartId == null) {
+            throw new IllegalArgumentException("cartId는 필수입니다.");
+        }
+        this.cartId = cartId;
+    }
+}

--- a/src/main/java/org/example/mollyapi/order/dto/DirectOrderRequestDto.java
+++ b/src/main/java/org/example/mollyapi/order/dto/DirectOrderRequestDto.java
@@ -1,0 +1,28 @@
+package org.example.mollyapi.order.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DirectOrderRequestDto {
+    @NotNull
+    private Long itemId;
+
+    @NotNull
+    private Long quantity;
+
+    @JsonCreator
+    public DirectOrderRequestDto(
+            @JsonProperty("itemId") Long itemId,
+            @JsonProperty("quantity") Long quantity) {
+        if (itemId == null || quantity == null) {
+            throw new IllegalArgumentException("바로 주문 시 itemId와 quantity는 필수입니다.");
+        }
+        this.itemId = itemId;
+        this.quantity = quantity;
+    }
+}

--- a/src/main/java/org/example/mollyapi/order/dto/OrderRequestWrapper.java
+++ b/src/main/java/org/example/mollyapi/order/dto/OrderRequestWrapper.java
@@ -1,0 +1,29 @@
+package org.example.mollyapi.order.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class OrderRequestWrapper {
+    private List<CartOrderRequestDto> cartOrderRequests;
+    private DirectOrderRequestDto directOrderRequest;
+
+    @JsonCreator
+    public OrderRequestWrapper(
+            @JsonProperty("cartOrderRequests") List<CartOrderRequestDto> cartOrderRequests,
+            @JsonProperty("directOrderRequest") DirectOrderRequestDto directOrderRequest) {
+
+        // 장바구니 주문과 바로 주문을 동시에 받을 수 없음
+        if ((cartOrderRequests != null && !cartOrderRequests.isEmpty()) && directOrderRequest != null) {
+            throw new IllegalArgumentException("장바구니 주문(cartOrderRequests)과 바로 주문(directOrderRequest)을 동시에 보낼 수 없습니다.");
+        }
+
+        this.cartOrderRequests = cartOrderRequests;
+        this.directOrderRequest = directOrderRequest;
+    }
+}


### PR DESCRIPTION
## 개요
- `CartOrderRequestDto`: cartId만 받도록 수정
- `DirectOrderRequestDto`: itemId와 quantity를 받도록 수정
- `OrderRequestWrapper`:
  - `cartOrderRequests`와 `directOrderRequests`를 동시에 받을 수 없도록 제한(장바구니 주문과 바로 주문을 중첩할 수 없음)
- `OrderController.createOrder`:
  - `cartOrderRequests`만 있을 경우 → 장바구니 주문 처리
  - `directOrderRequests`만 있을 경우 → 바로 주문 처리
  - 둘 다 없으면 예외 발생
<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

장바구니 주문
<img width="1041" alt="orderfixv201" src="https://github.com/user-attachments/assets/499dd758-012b-4980-b04e-769b4e186919" />

바로 주문
<img width="1038" alt="orderfixv202" src="https://github.com/user-attachments/assets/350353e8-ff46-4c8d-a06f-d6d890911811" />



- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
