### PR TITLE
204 fix: 사용자 주문내역 조회시 응답 데이터 변경

### DIFF
--- a/src/main/java/org/example/mollyapi/order/dto/OrderDetailWithReviewResponseDto.java
+++ b/src/main/java/org/example/mollyapi/order/dto/OrderDetailWithReviewResponseDto.java
@@ -1,40 +1,36 @@
 package org.example.mollyapi.order.dto;
 
-import lombok.Builder;
-import lombok.Getter;
 import org.example.mollyapi.order.entity.OrderDetail;
 import org.example.mollyapi.review.repository.ReviewRepository;
 
-@Getter
-@Builder
-public class OrderDetailWithReviewResponseDto {
-    private Long orderId;
-    private Long orderDetailId;
-    private Long productId;
-    private Long itemId;
-    private String brandName;
-    private String productName;
-    private String size;
-    private Long price;
-    private Long quantity;
-    private String image;
-    private String color;
-    private String reviewType;
-
+public record OrderDetailWithReviewResponseDto(
+        Long orderId,
+        Long orderDetailId,
+        Long productId,
+        Long itemId,
+        String brandName,
+        String productName,
+        String size,
+        Long price,
+        Long quantity,
+        String image,
+        String color,
+        String reviewType
+) {
     public static OrderDetailWithReviewResponseDto from(Long userId, OrderDetail orderDetail, ReviewRepository reviewRepository) {
-        return OrderDetailWithReviewResponseDto.builder()
-                .orderId(orderDetail.getOrder().getId())
-                .orderDetailId(orderDetail.getId())
-                .productId(orderDetail.getProductItem().getProduct().getId())
-                .itemId(orderDetail.getProductItem().getId())
-                .brandName(orderDetail.getBrandName())
-                .productName(orderDetail.getProductItem().getProduct().getProductName())
-                .size(orderDetail.getProductItem().getSize())
-                .price(orderDetail.getPrice())
-                .quantity(orderDetail.getQuantity())
-                .image(orderDetail.getProductItem().getProduct().getThumbnail().getStoredFileName())
-                .color(orderDetail.getProductItem().getColor())
-                .reviewType(reviewRepository.getReviewStatus(orderDetail.getId(), userId))
-                .build();
+        return new OrderDetailWithReviewResponseDto(
+                orderDetail.getOrder().getId(),
+                orderDetail.getId(),
+                orderDetail.getProductItem().getProduct().getId(),
+                orderDetail.getProductItem().getId(),
+                orderDetail.getBrandName(),
+                orderDetail.getProductName(),
+                orderDetail.getSize(),
+                orderDetail.getPrice(),
+                orderDetail.getQuantity(),
+                orderDetail.getProductItem().getProduct().getThumbnail().getStoredFileName(),
+                orderDetail.getProductItem().getColor(),
+                reviewRepository.getReviewStatus(orderDetail.getId(), userId)
+        );
     }
 }

--- a/src/main/java/org/example/mollyapi/order/dto/OrderHistoryResponseDto.java
+++ b/src/main/java/org/example/mollyapi/order/dto/OrderHistoryResponseDto.java
@@ -26,7 +26,8 @@ public record OrderHistoryResponseDto(
             OrderStatus orderStatus,
             String orderedAt,
             Long paymentAmount,
-            String deliveryStatus
+            String deliveryStatus,
+            List<OrderDetailWithReviewResponseDto> orderDetails
     ) {
         private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
@@ -38,8 +39,10 @@ public record OrderHistoryResponseDto(
                     order.getStatus(),
                     order.getOrderedAt() != null ? order.getOrderedAt().format(FORMATTER) : null,
                     paymentAmount,
-                    order.getDelivery() != null ? order.getDelivery().getStatus().name() : null
-            );
+                    order.getDelivery() != null ? order.getDelivery().getStatus().name() : null,
+                    order.getOrderDetails().stream()
+                            .map(orderDetail -> OrderDetailWithReviewResponseDto.from(order.getUser().getUserId(), orderDetail, reviewRepository))
+                            .collect(Collectors.toList()));
         }
     }
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
사용자 주문내역(GET /orders/user) 조회시, 응답 데이터 변경

<!---- Resolves: #(Isuue Number) -->
Resolves: #204 

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [X] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
## 생략된 orderDetails 추가
<img width="1065" alt="스크린샷 2025-03-24 오전 10 09 52" src="https://github.com/user-attachments/assets/b81ff1c1-80bd-4210-a126-3190d51f3f8b" />

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
