### PR TITLE
[#216] fix: 커서기반 쿼리 조회 시 사이즈 + 1 누락 수정

### DIFF
--- a/src/main/java/org/example/mollyapi/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/org/example/mollyapi/product/repository/ProductRepositoryImpl.java
@@ -6,6 +6,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 import org.example.mollyapi.product.dto.*;
 import org.example.mollyapi.product.enums.OrderBy;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -64,7 +65,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
         ProductItemSubQuery subQuery = new ProductItemSubQuery(
                 condition == null || condition.orderBy() == null ? OrderBy.CREATED_AT : condition.orderBy(),
                 offset,
-                pageable.isPaged() ? (long)pageable.getPageSize() : null);
+                pageable.isPaged() ? (long)pageable.getPageSize()+1 : null);
 
         // 서브쿼리 조건 추가 및 toString
         String subQueryString = subQuery
@@ -98,7 +99,8 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
             content.remove(pageable.getPageSize());
             hasNext = true;
         }
-        return new SliceImpl<>(content, pageable, hasNext);
+        Pageable p = pageable != null && pageable.isPaged() ?  PageRequest.of(offset != null && offset > 0 ? 1 : 0, pageable.getPageSize()) : pageable;
+        return new SliceImpl<>(content, p, hasNext);
     }
 
 }

--- a/src/test/java/org/example/mollyapi/product/repository/ProductRepositoryImplTest.java
+++ b/src/test/java/org/example/mollyapi/product/repository/ProductRepositoryImplTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDate;
@@ -281,6 +282,79 @@ class ProductRepositoryImplTest {
 
         //then
         assertThat(content).hasSize(1)
+                .extracting("brandName", "categoryId")
+                .contains(
+                        tuple("Nike", 3L)
+                );
+    }
+
+    @DisplayName("offset이 null이거나 0이면 조회 결과의 첫 요소를 기준으로 사이즈만큼 가져오고 isFirst는 true이다")
+    @Test
+    void findByCondition_firstPage() {
+        // given
+        ProductFilterCondition condition = new ProductFilterCondition(List.of("WHITE"), null, null, null, null, null, null, null, OrderBy.VIEW_COUNT);
+        // 최소값보다 비싼 상품
+        createTestProduct("WHITE", "White", "M", 2L, "Adidas", 110000L, 250L, 200L, 500L);
+        createTestProduct("WHITE", "Blue", "M", 1L, "Nike", 80000L, 200L, 150L, 300L);
+        createTestProduct("WHITE", "Gray", "M", 3L, "Nike", 30000L, 150L, 130L, 100L);
+        createTestProduct("BLUE", "Gray", "M", 3L, "Nike", 30000L, 200L, 130L, 100L);
+
+        // when
+        PageRequest pageable = PageRequest.of(0, 1);
+        Slice<ProductAndThumbnailDto> byCondition = productRepository.findByCondition(condition, pageable, 0L);
+
+        //then
+        assertThat(byCondition.isFirst()).isTrue();
+        assertThat(byCondition.getContent()).hasSize(1)
+                .extracting("brandName", "categoryId")
+                .contains(
+                        tuple("Adidas", 2L)
+                );
+    }
+
+    @DisplayName("offset이 조회 결과의 중간이면서 다음 데이터가 남아있으면 isFirst와 isLast는 false이다")
+    @Test
+    void findByCondition_midPage() {
+        // given
+        ProductFilterCondition condition = new ProductFilterCondition(List.of("WHITE"), null, null, null, null, null, null, null, OrderBy.VIEW_COUNT);
+        // 최소값보다 비싼 상품
+        Product testProduct = createTestProduct("WHITE", "White", "M", 2L, "Adidas", 110000L, 250L, 200L, 500L);
+        createTestProduct("WHITE", "Blue", "M", 1L, "Nike", 80000L, 200L, 150L, 300L);
+        createTestProduct("WHITE", "Gray", "M", 3L, "Nike", 30000L, 150L, 130L, 100L);
+        createTestProduct("BLUE", "Gray", "M", 3L, "Nike", 30000L, 200L, 130L, 100L);
+
+        // when
+        PageRequest pageable = PageRequest.of(0, 1);
+        Slice<ProductAndThumbnailDto> byCondition = productRepository.findByCondition(condition, pageable, testProduct.getId());
+
+        //then
+        assertThat(byCondition.isFirst()).isFalse();
+        assertThat(byCondition.isLast()).isFalse();
+        assertThat(byCondition.getContent()).hasSize(1)
+                .extracting("brandName", "categoryId")
+                .contains(
+                        tuple("Nike", 1L)
+                );
+    }
+
+    @DisplayName("조회 결과의 다음 데이터가 남아있지 않다면 isLast는 true이다")
+    @Test
+    void findByCondition_lastPage() {
+        // given
+        ProductFilterCondition condition = new ProductFilterCondition(List.of("WHITE"), null, null, null, null, null, null, null, OrderBy.VIEW_COUNT);
+        // 최소값보다 비싼 상품
+        createTestProduct("WHITE", "White", "M", 2L, "Adidas", 110000L, 250L, 200L, 500L);
+        Product testProduct = createTestProduct("WHITE", "Blue", "M", 1L, "Nike", 80000L, 200L, 150L, 300L);
+        createTestProduct("WHITE", "Gray", "M", 3L, "Nike", 30000L, 150L, 130L, 100L);
+        createTestProduct("BLUE", "Gray", "M", 3L, "Nike", 30000L, 200L, 130L, 100L);
+
+        // when
+        PageRequest pageable = PageRequest.of(0, 1);
+        Slice<ProductAndThumbnailDto> byCondition = productRepository.findByCondition(condition, pageable, testProduct.getId());
+
+        //then
+        assertThat(byCondition.isLast()).isTrue();
+        assertThat(byCondition.getContent()).hasSize(1)
                 .extracting("brandName", "categoryId")
                 .contains(
                         tuple("Nike", 3L)


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 커서 기반에서 사이즈보다 + 1만큼 조회해야하는데 반영되지 않는 코드를 수정
- 추가로 isFirst, isLast 검증하는 테스트코드 추가
- 
<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

<img width="436" alt="image" src="https://github.com/user-attachments/assets/f109ad92-a30d-48bb-b8ab-8abad69d222d" />


- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
